### PR TITLE
Fix IconDrawable issue on Android 5.0.x and 5.1

### DIFF
--- a/android-iconify/src/main/java/com/joanzapata/android/iconify/IconDrawable.java
+++ b/android-iconify/src/main/java/com/joanzapata/android/iconify/IconDrawable.java
@@ -68,7 +68,7 @@ public class IconDrawable extends Drawable {
         this.icon = icon;
         paint = new TextPaint();
         paint.setTypeface(Iconify.getTypeface(context));
-        paint.setStyle(Paint.Style.STROKE);
+        paint.setStyle(Paint.Style.FILL);
         paint.setTextAlign(Paint.Align.CENTER);
         paint.setUnderlineText(false);
         paint.setColor(Color.BLACK);


### PR DESCRIPTION
Fix issue with only edge of the icon rendered

Close issue #75