### PR TITLE
Fixed issue 93: https://github.com/JoanZapata/android-iconify/issues/93

### DIFF
--- a/android-iconify/src/main/java/com/joanzapata/iconify/IconDrawable.java
+++ b/android-iconify/src/main/java/com/joanzapata/iconify/IconDrawable.java
@@ -6,6 +6,8 @@ import android.graphics.drawable.Drawable;
 import android.text.TextPaint;
 import android.util.TypedValue;
 
+import java.lang.Override;
+
 import static android.util.TypedValue.COMPLEX_UNIT_DIP;
 
 /**
@@ -32,6 +34,8 @@ public class IconDrawable extends Drawable {
     private int size = -1;
 
     private int alpha = 255;
+
+    private IconDrawable.ConstantState constantState;
 
     /**
      * Create an IconDrawable.
@@ -66,6 +70,7 @@ public class IconDrawable extends Drawable {
         paint.setUnderlineText(false);
         paint.setColor(Color.BLACK);
         paint.setAntiAlias(true);
+        constantState = new IconDrawable.ConstantState();
     }
 
     /**
@@ -196,6 +201,15 @@ public class IconDrawable extends Drawable {
         return this.alpha;
     }
 
+    /*
+     * Fixes problem with setIcon() method, issue found (and wrongfully closed) here:
+     * https://github.com/JoanZapata/android-iconify/issues/93
+     */
+    @Override
+    public Drawable.ConstantState getConstantState(){
+        return constantState;
+    }
+
     /**
      * Sets paint style.
      * @param style to be applied
@@ -218,4 +232,17 @@ public class IconDrawable extends Drawable {
                 COMPLEX_UNIT_DIP, dp,
                 context.getResources().getDisplayMetrics());
     }
+
+    public static class ConstantState extends Drawable.ConstantState{
+
+        public Drawable newDrawable(){
+            return IconDrawable.this;
+        }
+
+        public int getChangingConfigurations(){
+            return 0;
+        }
+
+    }
+
 }


### PR DESCRIPTION
When attempting to set an ActionBar MenuItem with an IconDrawable, such as:

```Java
MenuItem n = menu.findItem(R.id.action_notifications).setIcon(new IconDrawable(this,
                Iconify.IconValue.fa_globe).colorRes(R.color.white).actionBarSize());
```
causes a NullPointerException on the setIcon() call. This is due to the internal setIcon() code calling getConstantState().newDrawable(). Since this is not supplied in IconDrawable it causes a NullPointerException. For more details see the issue here: https://github.com/JoanZapata/android-iconify/issues/93. The issue has wrongfully been closed but should now be fixed with the supplied update. Please test and verify that my update is correct and causes no other issues.