### PR TITLE
Enable use of color state lists with IconDrawable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ public class MyApplication extends Application {
         Iconify
             .with(new FontAwesomeModule())
             .with(new EntypoModule())
-            .with(new TypiconsModule());
-            .with(new MaterialModule());
-            .with(new MeteoconsModule());
-            .with(new WeathericonsModule());
-            .with(new SimpleLineIconsModule());
+            .with(new TypiconsModule())
+            .with(new MaterialModule())
+            .with(new MaterialCommunityModule())
+            .with(new MeteoconsModule())
+            .with(new WeathericonsModule())
+            .with(new SimpleLineIconsModule())
             .with(new IoniconsModule());
     }
 }

--- a/android-iconify/src/main/java/com/joanzapata/iconify/IconDrawable.java
+++ b/android-iconify/src/main/java/com/joanzapata/iconify/IconDrawable.java
@@ -1,6 +1,7 @@
 package com.joanzapata.iconify;
 
 import android.content.Context;
+import android.content.res.ColorStateList;
 import android.graphics.*;
 import android.graphics.drawable.Drawable;
 import android.text.TextPaint;
@@ -33,6 +34,7 @@ public class IconDrawable extends Drawable {
     private int size = -1;
 
     private int alpha = 255;
+    private ColorStateList colorStateList;
 
     /**
      * Create an IconDrawable.
@@ -130,7 +132,11 @@ public class IconDrawable extends Drawable {
      * @return The current IconDrawable for chaining.
      */
     public IconDrawable colorRes(int colorRes) {
-        paint.setColor(context.getResources().getColor(colorRes));
+        colorStateList = context.getResources().getColorStateList(colorRes);
+        if (colorStateList == null) {
+            colorStateList = ColorStateList.valueOf(Color.BLACK);
+        }
+        paint.setColor(colorStateList.getColorForState(getState(), colorStateList.getDefaultColor()));
         invalidateSelf();
         return this;
     }
@@ -175,11 +181,21 @@ public class IconDrawable extends Drawable {
     }
 
     @Override
-    public boolean setState(int[] stateSet) {
-        int oldValue = paint.getAlpha();
-        int newValue = isEnabled(stateSet) ? alpha : alpha / 2;
-        paint.setAlpha(newValue);
-        return oldValue != newValue;
+    protected boolean onStateChange(int[] state) {
+        boolean changed;
+        if (colorStateList == null || !colorStateList.isStateful()) {
+            int oldValue = paint.getAlpha();
+            int newValue = isEnabled(state) ? alpha : alpha / 2;
+            paint.setAlpha(newValue);
+            changed = oldValue != newValue;
+        } else {
+            int oldColor = paint.getColor();
+            int newColor = colorStateList.getColorForState(state, oldColor);
+            paint.setColor(newColor);
+            changed = oldColor != newColor;
+        }
+
+        return changed;
     }
 
     @Override


### PR DESCRIPTION
- allows to set ColorStateList resources on IconDrawable
- keeps old behavior when color resource does not have multiple states