### PR TITLE
Add IconImageView and IconImageButton

### DIFF
--- a/android-iconify/src/main/AndroidManifest.xml
+++ b/android-iconify/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.joanzapata.android.iconify">
+<manifest package="com.joanzapata.iconify">
 
 </manifest>

--- a/android-iconify/src/main/java/com/joanzapata/iconify/IconDrawable.java
+++ b/android-iconify/src/main/java/com/joanzapata/iconify/IconDrawable.java
@@ -146,6 +146,14 @@ public class IconDrawable extends Drawable {
         return this;
     }
 
+    /**
+     * Returns the icon to be displayed
+     * @return The icon
+     */
+    public final Icon getIcon() {
+        return icon;
+    }
+
     @Override
     public int getIntrinsicHeight() {
         return size;

--- a/android-iconify/src/main/java/com/joanzapata/iconify/widget/IconImageButton.java
+++ b/android-iconify/src/main/java/com/joanzapata/iconify/widget/IconImageButton.java
@@ -1,0 +1,70 @@
+package com.joanzapata.iconify.widget;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.Color;
+import android.graphics.drawable.Drawable;
+import android.util.AttributeSet;
+import android.widget.ImageButton;
+
+import com.joanzapata.iconify.Icon;
+import com.joanzapata.iconify.IconDrawable;
+import com.joanzapata.iconify.R;
+
+public class IconImageButton extends ImageButton {
+
+    private int color;
+
+    public IconImageButton(Context context) {
+        super(context);
+    }
+
+    public IconImageButton(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public IconImageButton(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        final TypedArray a = context.obtainStyledAttributes(
+                attrs, R.styleable.IconImageView, defStyleAttr, 0);
+        color = a.getColor(R.styleable.IconImageView_iconColor, Color.BLACK);
+        String iconKey = a.getString(R.styleable.IconImageView_iconName);
+        if (iconKey != null) {
+            setImageDrawable(new IconDrawable(context, iconKey));
+        }
+        a.recycle();
+    }
+
+    public void setIcon(Icon icon) {
+        setImageDrawable(new IconDrawable(getContext(), icon));
+    }
+
+    public final Icon getIcon() {
+        Drawable drawable = getDrawable();
+        if (drawable instanceof IconDrawable) {
+            return ((IconDrawable) drawable).getIcon();
+        }
+        return null;
+    }
+
+    public void setIconColor(int color) {
+        this.color = color;
+        Drawable drawable = getDrawable();
+        if (drawable instanceof IconDrawable) {
+            ((IconDrawable) drawable).color(color);
+        }
+    }
+
+    public void setIconColorResource(int colorResId) {
+        setIconColor(getContext().getResources().getColor(colorResId));
+    }
+
+    @Override
+    public void setImageDrawable(Drawable drawable) {
+        if (drawable instanceof IconDrawable && drawable != getDrawable()) {
+            ((IconDrawable) drawable).color(color);
+        }
+        super.setImageDrawable(drawable);
+    }
+
+}

--- a/android-iconify/src/main/java/com/joanzapata/iconify/widget/IconImageView.java
+++ b/android-iconify/src/main/java/com/joanzapata/iconify/widget/IconImageView.java
@@ -1,0 +1,70 @@
+package com.joanzapata.iconify.widget;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.Color;
+import android.graphics.drawable.Drawable;
+import android.util.AttributeSet;
+import android.widget.ImageView;
+
+import com.joanzapata.iconify.Icon;
+import com.joanzapata.iconify.IconDrawable;
+import com.joanzapata.iconify.R;
+
+public class IconImageView extends ImageView {
+
+    private int color;
+
+    public IconImageView(Context context) {
+        super(context);
+    }
+
+    public IconImageView(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public IconImageView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        final TypedArray a = context.obtainStyledAttributes(
+                attrs, R.styleable.IconImageView, defStyleAttr, 0);
+        color = a.getColor(R.styleable.IconImageView_iconColor, Color.BLACK);
+        String iconKey = a.getString(R.styleable.IconImageView_iconName);
+        if (iconKey != null) {
+            setImageDrawable(new IconDrawable(context, iconKey));
+        }
+        a.recycle();
+    }
+
+    public void setIcon(Icon icon) {
+        setImageDrawable(new IconDrawable(getContext(), icon));
+    }
+
+    public final Icon getIcon() {
+        Drawable drawable = getDrawable();
+        if (drawable instanceof IconDrawable) {
+            return ((IconDrawable) drawable).getIcon();
+        }
+        return null;
+    }
+
+    public void setIconColor(int color) {
+        this.color = color;
+        Drawable drawable = getDrawable();
+        if (drawable instanceof IconDrawable) {
+            ((IconDrawable) drawable).color(color);
+        }
+    }
+
+    public void setIconColorResource(int colorResId) {
+        setIconColor(getContext().getResources().getColor(colorResId));
+    }
+
+    @Override
+    public void setImageDrawable(Drawable drawable) {
+        if (drawable instanceof IconDrawable && drawable != getDrawable()) {
+            ((IconDrawable) drawable).color(color);
+        }
+        super.setImageDrawable(drawable);
+    }
+
+}

--- a/android-iconify/src/main/res/values/attrs.xml
+++ b/android-iconify/src/main/res/values/attrs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="IconImageView">
+        <attr name="iconName" format="string" />
+        <attr name="iconColor" format="color" />
+    </declare-styleable>
+</resources>


### PR DESCRIPTION
Although single icons can be rendered as text in text views, it requires setting a fixed size. Using a drawable allows it to automatically scale according to the size of the widget. Therefore, this pull request introduces `IconImageView` and `IconImageButton` to enable using the drawable in XML. They also define custom attributes for the icon properties, which improves readability and extendibility. Furthermore, extending `ImageView` and `ImageButton` provides easy inoperability with other drawables (i.e when switching between XML drawable resources and `IconDrawable`).

Resolves #132