### PR TITLE
Add pulsing spin animation

### DIFF
--- a/android-iconify/src/main/java/com/joanzapata/iconify/internal/Animation.java
+++ b/android-iconify/src/main/java/com/joanzapata/iconify/internal/Animation.java
@@ -1,0 +1,15 @@
+package com.joanzapata.iconify.internal;
+
+public enum Animation {
+    SPIN("spin"), PULSE("pulse"), NONE(null);
+
+    private final String token;
+
+    Animation(String token) {
+        this.token = token;
+    }
+
+    String getToken() {
+        return token;
+    }
+}

--- a/android-iconify/src/main/java/com/joanzapata/iconify/internal/CustomTypefaceSpan.java
+++ b/android-iconify/src/main/java/com/joanzapata/iconify/internal/CustomTypefaceSpan.java
@@ -4,11 +4,19 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Rect;
 import android.graphics.Typeface;
+import android.os.SystemClock;
 import android.text.style.ReplacementSpan;
 import com.joanzapata.iconify.Icon;
 
 public class CustomTypefaceSpan extends ReplacementSpan {
     private static final int ROTATION_DURATION = 2000;
+    // Font Awesome uses 8-step rotation for pulse, and
+    // it seems to have the only pulsing spinner. If
+    // spinners with different pulses are introduced at
+    // some point, then a pulse property can be
+    // implemented for the icons.
+    static final int ROTATION_PULSES = 8;
+    private static final int ROTATION_PULSE_DURATION = ROTATION_DURATION / ROTATION_PULSES;
     private static final Rect TEXT_BOUNDS = new Rect();
     private static final Paint LOCAL_PAINT = new Paint();
     private static final float BASELINE_RATIO = 1 / 7f;
@@ -18,21 +26,21 @@ public class CustomTypefaceSpan extends ReplacementSpan {
     private final float iconSizePx;
     private final float iconSizeRatio;
     private final int iconColor;
-    private final boolean rotate;
+    private final Animation animation;
     private final boolean baselineAligned;
     private final long rotationStartTime;
 
     public CustomTypefaceSpan(Icon icon, Typeface type,
             float iconSizePx, float iconSizeRatio, int iconColor,
-            boolean rotate, boolean baselineAligned) {
-        this.rotate = rotate;
+            Animation animation, boolean baselineAligned) {
+        this.animation = animation != null ? animation : Animation.NONE;
         this.baselineAligned = baselineAligned;
         this.icon = String.valueOf(icon.character());
         this.type = type;
         this.iconSizePx = iconSizePx;
         this.iconSizeRatio = iconSizeRatio;
         this.iconColor = iconColor;
-        this.rotationStartTime = System.currentTimeMillis();
+        this.rotationStartTime = SystemClock.uptimeMillis();
     }
 
     @Override
@@ -59,8 +67,20 @@ public class CustomTypefaceSpan extends ReplacementSpan {
         paint.getTextBounds(icon, 0, 1, TEXT_BOUNDS);
         canvas.save();
         float baselineRatio = baselineAligned ? 0f : BASELINE_RATIO;
-        if (rotate) {
-            float rotation = (System.currentTimeMillis() - rotationStartTime) / (float) ROTATION_DURATION * 360f;
+        if (animation != Animation.NONE) {
+            long timeElapsed = SystemClock.uptimeMillis() - rotationStartTime;
+            float rotation;
+            switch (animation) {
+                case PULSE:
+                    rotation = ((int) Math.floor(timeElapsed / (float) ROTATION_PULSE_DURATION))
+                            * 360f / ROTATION_PULSES;
+                    break;
+                case SPIN:
+                    rotation = timeElapsed / (float) ROTATION_DURATION * 360f;
+                    break;
+                default:
+                    throw new IllegalStateException();
+            }
             float centerX = x + TEXT_BOUNDS.width() / 2f;
             float centerY = y - TEXT_BOUNDS.height() / 2f + TEXT_BOUNDS.height() * baselineRatio;
             canvas.rotate(rotation, centerX, centerY);
@@ -72,15 +92,15 @@ public class CustomTypefaceSpan extends ReplacementSpan {
         canvas.restore();
     }
 
-    public boolean isAnimated() {
-        return rotate;
+    public Animation getAnimation() {
+        return animation;
     }
 
     private void applyCustomTypeFace(Paint paint, Typeface tf) {
         paint.setFakeBoldText(false);
         paint.setTextSkewX(0f);
         paint.setTypeface(tf);
-        if (rotate) paint.clearShadowLayer();
+        if (animation != Animation.NONE) paint.clearShadowLayer();
         if (iconSizeRatio > 0) paint.setTextSize(paint.getTextSize() * iconSizeRatio);
         else if (iconSizePx > 0) paint.setTextSize(iconSizePx);
         if (iconColor < Integer.MAX_VALUE) paint.setColor(iconColor);


### PR DESCRIPTION
The Font Awesome CSS framework has a [pulse animation][] that rotates an icon in 8 steps, which matches the structure of it's pulsing spinner. This has been implemented with the "pulse" token here. Since Font Awesome seems to have the only dotted pulsing spinner out of the current font set, this seems a reasonable generic implementation at the moment. If at some point spinners with different pulses need to be handled, then a pulse property can be introduced for the icons, with 8 as the default count.

[pulse animation]: https://fortawesome.github.io/Font-Awesome/examples/#animated