### PR TITLE
Fix WeathericonsIcons name error

### DIFF
--- a/android-iconify-weathericons/src/main/java/com/joanzapata/iconify/fonts/WeathericonsIcons.java
+++ b/android-iconify-weathericons/src/main/java/com/joanzapata/iconify/fonts/WeathericonsIcons.java
@@ -524,7 +524,7 @@ public enum WeathericonsIcons implements Icon {
 
     @Override
     public String key() {
-        return name().replace('_', '_');
+        return name().replace('_', '-');
     }
 
     @Override


### PR DESCRIPTION
I think this maybe a "slip of a pen", although it doesn't affect the function, but all other icons use '-' replace '_' as its name, I don't know why here not replace it.