### PR TITLE
Add supports for characters outside the initial Basic Multilingual Plane

### DIFF
--- a/android-iconify-entypo/src/main/java/com/joanzapata/iconify/fonts/EntypoIcons.java
+++ b/android-iconify-entypo/src/main/java/com/joanzapata/iconify/fonts/EntypoIcons.java
@@ -427,7 +427,7 @@ public enum EntypoIcons implements Icon {
     }
 
     @Override
-    public char character() {
-        return character;
+    public String character() {
+        return String.valueOf(character);
     }
 }

--- a/android-iconify-fontawesome/src/main/java/com/joanzapata/iconify/fonts/FontAwesomeIcons.java
+++ b/android-iconify-fontawesome/src/main/java/com/joanzapata/iconify/fonts/FontAwesomeIcons.java
@@ -710,7 +710,7 @@ public enum FontAwesomeIcons implements Icon {
     }
 
     @Override
-    public char character() {
-        return character;
+    public String character() {
+        return String.valueOf(character);
     }
 }

--- a/android-iconify-ionicons/src/main/java/com/joanzapata/iconify/fonts/IoniconsIcons.java
+++ b/android-iconify-ionicons/src/main/java/com/joanzapata/iconify/fonts/IoniconsIcons.java
@@ -749,7 +749,7 @@ public enum IoniconsIcons implements Icon {
     }
 
     @Override
-    public char character() {
-        return character;
+    public String character() {
+        return String.valueOf(character);
     }
 }

--- a/android-iconify-material-community/src/main/java/com/joanzapata/iconify/fonts/MaterialCommunityIcons.java
+++ b/android-iconify-material-community/src/main/java/com/joanzapata/iconify/fonts/MaterialCommunityIcons.java
@@ -1473,7 +1473,7 @@ public enum MaterialCommunityIcons implements Icon {
     }
 
     @Override
-    public char character() {
-        return character;
+    public String character() {
+        return String.valueOf(character);
     }
 }

--- a/android-iconify-material/src/main/java/com/joanzapata/iconify/fonts/MaterialIcons.java
+++ b/android-iconify-material/src/main/java/com/joanzapata/iconify/fonts/MaterialIcons.java
@@ -811,7 +811,7 @@ public enum MaterialIcons implements Icon {
     }
 
     @Override
-    public char character() {
-        return character;
+    public String character() {
+        return String.valueOf(character);
     }
 }

--- a/android-iconify-meteocons/src/main/java/com/joanzapata/iconify/fonts/MeteoconsIcons.java
+++ b/android-iconify-meteocons/src/main/java/com/joanzapata/iconify/fonts/MeteoconsIcons.java
@@ -63,7 +63,7 @@ public enum MeteoconsIcons implements Icon {
     }
 
     @Override
-    public char character() {
-        return character;
+    public String character() {
+        return String.valueOf(character);
     }
 }

--- a/android-iconify-simplelineicons/src/main/java/com/joanzapata/iconify/fonts/SimpleLineIconsIcons.java
+++ b/android-iconify-simplelineicons/src/main/java/com/joanzapata/iconify/fonts/SimpleLineIconsIcons.java
@@ -178,7 +178,7 @@ public enum SimpleLineIconsIcons implements Icon {
     }
 
     @Override
-    public char character() {
-        return character;
+    public String character() {
+        return String.valueOf(character);
     }
 }

--- a/android-iconify-typicons/src/main/java/com/joanzapata/iconify/fonts/TypiconsIcons.java
+++ b/android-iconify-typicons/src/main/java/com/joanzapata/iconify/fonts/TypiconsIcons.java
@@ -352,7 +352,7 @@ public enum TypiconsIcons implements Icon {
     }
 
     @Override
-    public char character() {
-        return character;
+    public String character() {
+        return String.valueOf(character);
     }
 }

--- a/android-iconify-weathericons/src/main/java/com/joanzapata/iconify/fonts/WeathericonsIcons.java
+++ b/android-iconify-weathericons/src/main/java/com/joanzapata/iconify/fonts/WeathericonsIcons.java
@@ -528,7 +528,7 @@ public enum WeathericonsIcons implements Icon {
     }
 
     @Override
-    public char character() {
-        return character;
+    public String character() {
+        return String.valueOf(character);
     }
 }

--- a/android-iconify/src/main/java/com/joanzapata/iconify/Icon.java
+++ b/android-iconify/src/main/java/com/joanzapata/iconify/Icon.java
@@ -8,7 +8,8 @@ public interface Icon {
     /** The key of icon, for example 'fa-ok' */
     String key();
 
-    /** The character matching the key in the font, for example '\u4354' */
-    char character();
+    /** The character matching the key in the font, for example String.valueOf('\u4354') or in case
+     * of characters outside the initial Basic Multilingual Plane, simply "\uD83D\uDC64" */
+    String character();
 
 }

--- a/android-iconify/src/main/java/com/joanzapata/iconify/IconDrawable.java
+++ b/android-iconify/src/main/java/com/joanzapata/iconify/IconDrawable.java
@@ -162,8 +162,8 @@ public class IconDrawable extends Drawable {
         int height = bounds.height();
         paint.setTextSize(height);
         Rect textBounds = new Rect();
-        String textValue = String.valueOf(icon.character());
-        paint.getTextBounds(textValue, 0, 1, textBounds);
+        String textValue = icon.character();
+        paint.getTextBounds(textValue, 0, textValue.length(), textBounds);
         int textHeight = textBounds.height();
         float textBottom = bounds.top + (height - textHeight) / 2f + textHeight - textBounds.bottom;
         canvas.drawText(textValue, bounds.exactCenterX(), textBottom, paint);


### PR DESCRIPTION
This commits adds the support to the chars outside the initial Basic Multilingual Plane simply replacing the Icon interface method `char character()` with  `String character()`.

Allows to user all the Unicode supplementary characters such as 👤, 📁, etc.

This probably should go in new release because it requires to update the old `Icon` interface.
